### PR TITLE
SYS-1336: Initial version of development environment

### DIFF
--- a/.camplit.env
+++ b/.camplit.env
@@ -1,0 +1,2 @@
+# Add general environment variables here,
+# suitable for public repository.

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,11 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local documents - may change based on project organization
+*.jpg
+*.pdf
+
+# Passwords and secrets
+*password*
+*secret*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,11 @@ RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN useradd -c "Campaign Lit app user" -d /home/camplit -s /bin/bash -m camplit
 USER camplit
 
-# Copy application files to image, and ensure camplit user owns everything
-COPY --chown=camplit:camplit . .
+# Switch to application directory
+WORKDIR /home/camplit
+
+# Copy relevant application files to image, and ensure camplit user owns everything
+COPY --chown=camplit:camplit requirements.txt .
 
 # Include local python bin into user's path, mostly for pip
 ENV PATH /home/camplit/.local/bin:${PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim-bullseye
+
+# Install latest version of tesseract, after installing dependencies.
+# Also install poppler-utils, for pdf to image conversion utilities.
+RUN apt-get update \
+    && apt-get install lsb-release wget apt-transport-https gnupg -y -qq \
+    && echo "deb https://notesalexp.org/tesseract-ocr5/$(lsb_release -cs)/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/notesalexp.list \
+    && wget -qO- https://notesalexp.org/debian/alexp_key.asc | tee /etc/apt/trusted.gpg.d/alexp_key.asc \
+    && apt-get update \
+    && apt-get install tesseract-ocr -y -qq \
+    && apt-get install poppler-utils -y -qq
+
+# Set correct timezone
+RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+
+# Create non-privileged user and switch context to that user
+RUN useradd -c "Campaign Lit app user" -d /home/camplit -s /bin/bash -m camplit
+USER camplit
+
+# Copy application files to image, and ensure camplit user owns everything
+COPY --chown=camplit:camplit . .
+
+# Include local python bin into user's path, mostly for pip
+ENV PATH /home/camplit/.local/bin:${PATH}
+
+# Make sure pip is up to date, and don't complain if it isn't yet
+RUN pip install --upgrade pip --disable-pip-version-check
+
+# Install requirements for this application
+RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location

--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ See `requirements.txt` for specific versions used, and links to documentation fo
 
 2. Change directory into the project.
 
-   ```$ cd oral-history-staff-ui```
+   ```$ cd campaign-literature-ocr```
 
 3. Build using docker-compose.
 
    ```$ docker-compose build```
 
-4. Bring the system up, with containers running in the background.
+4. Get a copy of `.camplit_secrets.env` from a colleage and place it in the current directory.
+
+5. Bring the system up, with containers running in the background.
 
    ```$ docker-compose up -d```
 
-5. Logs can be viewed, if needed (`-f` to tail logs).
+6. Logs can be viewed, if needed (`-f` to tail logs).
 
-   ```
-   $ docker-compose logs -f camplit
-   ```
+   ```$ docker-compose logs -f camplit```
 
-6. Run commands in the containers, if needed.
+7. Run commands in the containers, if needed.
 
    ```
    # Run python shell
@@ -61,6 +61,6 @@ See `requirements.txt` for specific versions used, and links to documentation fo
    # Run a privileged bash shell as root, in case it's needed
    $ docker-compose exec -u root camplit bash
 
-7. Shut down the system when done.
+8. Shut down the system when done.
 
    ```$ docker-compose down```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # campaign-literature-ocr
-Experimental project to use OCR &amp; AI/ML on UCLA Campaign Literature Collection
+Experimental project to use OCR and AI/ML on UCLA Campaign Literature Collection
+
+## Developer Information
+
+### Overview of environment
+
+The local development environment requires:
+* git (at least version 2)
+* docker (current version recommended: 20.10.12)
+* docker-compose (at least version 1.25.0; current recommended: 1.29.2)
+
+#### camplit container
+Everything important is in the docker container
+* [Tesseract OCR 5.3.1](https://tesseract-ocr.github.io/tessdoc/)
+* Python 3.11, with the latest versions of several packages
+  * [pillow (Python Imaging Library (Fork))](https://pypi.org/project/Pillow/)
+  * [pdf2image (wrapper around the pdftoppm and pdftocairo command line tools)](https://pypi.org/project/pdf2image/)
+  * [pytesseract (wrapper for Google's Tesseract-OCR)](https://pypi.org/project/pytesseract/)
+  * [nltk (Natural Language Toolkit)](https://pypi.org/project/nltk/)
+  * [spacy (Industrial-strength Natural Language Processing (NLP) in Python)](https://pypi.org/project/spacy/)
+  * [openai (Python client library for the OpenAI API)](https://pypi.org/project/openai/)
+
+See `requirements.txt` for specific versions used, and links to documentation for each package.
+
+### Setup
+1. Clone the repository.
+
+   ```$ git clone git@github.com:UCLALibrary/campaign-literature-ocr.git```
+
+2. Change directory into the project.
+
+   ```$ cd oral-history-staff-ui```
+
+3. Build using docker-compose.
+
+   ```$ docker-compose build```
+
+4. Bring the system up, with containers running in the background.
+
+   ```$ docker-compose up -d```
+
+5. Logs can be viewed, if needed (`-f` to tail logs).
+
+   ```
+   $ docker-compose logs -f camplit
+   ```
+
+6. Run commands in the containers, if needed.
+
+   ```
+   # Run python shell
+   $ docker-compose exec camplit python
+   
+   # Run tesseract (better examples to be added...)
+   $ docker-compose exec camplit tesseract --version
+
+   # Run bash shell, to just work in the container, as the camplit user
+   $ docker-compose exec camplit bash
+
+   # Run a privileged bash shell as root, in case it's needed
+   $ docker-compose exec -u root camplit bash
+
+7. Shut down the system when done.
+
+   ```$ docker-compose down```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.4'
+services:
+  camplit:
+    build: .
+    # Override the image's entrypoint, which otherwise runs the Dockerfile's entrypoint/cmd and exits.
+    # Setting "tty: true" allows the bash session to remain alive, keeping the
+    # container running; without it, bash immediately exits and the container stops.
+    tty: true
+    entrypoint: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,12 @@ version: '3.4'
 services:
   camplit:
     build: .
+    volumes:
+      - .:/home/camplit/campaign_lit
+    env_file:
+      - .camplit.env
+      # Local values not for the repo
+      - .camplit_secrets.env
     # Override the image's entrypoint, which otherwise runs the Dockerfile's entrypoint/cmd and exits.
     # Setting "tty: true" allows the bash session to remain alive, keeping the
     # container running; without it, bash immediately exits and the container stops.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pillow == 10.0.0
+pdf2image == 1.16.3 
+pytesseract == 0.3.10
+nltk == 3.8.1
+spacy == 3.5.4
+openai == 0.27.8


### PR DESCRIPTION
Implements [SYS-1336](https://jira.library.ucla.edu/browse/SYS-1336).

This combines the current version of `tesseract` into a standard Python 3.11 container, along with many of the packages we're likely to use.  More can be added as needed via `requirements.txt` as usual.  See `README.md` for details.

To test, follow instructions in `README.md`.  Since the base Python image is multi-architecture, I'm *hoping* `tesseract` will be installed appropriately into the container when `docker-compose build` runs, regardless of environment.

In an Intel environment:
```
$ docker-compose exec camplit tesseract --version
tesseract 5.3.1
 leptonica-1.79.0
  libgif 5.1.9 : libjpeg 6b (libjpeg-turbo 2.0.6) : libpng 1.6.37 : libtiff 4.2.0 : zlib 1.2.11 : libwebp 0.6.1 : libopenjp2 2.4.0
 Found AVX512BW
 Found AVX512F
 Found AVX512VNNI
 Found AVX2
 Found AVX
 Found FMA
 Found SSE4.1
 Found OpenMP 201511
 Found libarchive 3.4.3 zlib/1.2.11 liblzma/5.2.5 bz2lib/1.0.8 liblz4/1.9.3 libzstd/1.4.8
 Found libcurl/7.74.0 OpenSSL/1.1.1n zlib/1.2.11 brotli/1.0.9 libidn2/2.3.0 libpsl/0.21.0 (+libidn2/2.3.0) libssh2/1.9.0 nghttp2/1.43.0 librtmp/2.3
```
The ARM Apple environment should show `NEON` instead of the `AVX` and `SSE` lines.  I don't know if the various `lib` lines will vary.
